### PR TITLE
Prevent any interactions while paragliding

### DIFF
--- a/src/main/java/tictim/paraglider/ParagliderMod.java
+++ b/src/main/java/tictim/paraglider/ParagliderMod.java
@@ -2,7 +2,6 @@ package tictim.paraglider;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.MenuScreens.ScreenConstructor;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
@@ -13,15 +12,11 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.DyeableLeatherItem;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ClientRegistry;
 import net.minecraftforge.client.event.ColorHandlerEvent;
-import net.minecraftforge.client.event.DrawSelectionEvent;
-import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.client.settings.KeyModifier;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.event.entity.EntityAttributeModificationEvent;
@@ -107,22 +102,6 @@ public class ParagliderMod{
 						GLFW.GLFW_KEY_P, "key.categories.misc");
 				ClientRegistry.registerKeyBinding(paragliderSettingsKey);
 				ParagliderClientEventHandler.setParagliderSettingsKey(paragliderSettingsKey);
-
-				MinecraftForge.EVENT_BUS.addListener((final InputEvent.ClickInputEvent evt) -> {
-					// disables all interactions while paragliding
-					ItemStack itemInHand = Minecraft.getInstance().player.getMainHandItem();
-					if (itemInHand.getItem() instanceof ParagliderItem && ParagliderItem.isItemParagliding(itemInHand)) {
-						evt.setSwingHand(false);
-						evt.setCanceled(true);
-					}
-				});
-				MinecraftForge.EVENT_BUS.addListener((final DrawSelectionEvent.HighlightBlock evt) -> {
-					// disables drawing block highlights while paragliding (as blocks cannot be interacted with)
-					ItemStack itemInHand = Minecraft.getInstance().player.getMainHandItem();
-					if (itemInHand.getItem() instanceof ParagliderItem && ParagliderItem.isItemParagliding(itemInHand)) {
-						evt.setCanceled(true);
-					}
-				});
 			});
 		}
 

--- a/src/main/java/tictim/paraglider/ParagliderMod.java
+++ b/src/main/java/tictim/paraglider/ParagliderMod.java
@@ -2,6 +2,7 @@ package tictim.paraglider;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.MenuScreens.ScreenConstructor;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
@@ -12,11 +13,15 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.DyeableLeatherItem;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ClientRegistry;
 import net.minecraftforge.client.event.ColorHandlerEvent;
+import net.minecraftforge.client.event.DrawSelectionEvent;
+import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.client.settings.KeyModifier;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.event.entity.EntityAttributeModificationEvent;
@@ -102,6 +107,22 @@ public class ParagliderMod{
 						GLFW.GLFW_KEY_P, "key.categories.misc");
 				ClientRegistry.registerKeyBinding(paragliderSettingsKey);
 				ParagliderClientEventHandler.setParagliderSettingsKey(paragliderSettingsKey);
+
+				MinecraftForge.EVENT_BUS.addListener((final InputEvent.ClickInputEvent evt) -> {
+					// disables all interactions while paragliding
+					ItemStack itemInHand = Minecraft.getInstance().player.getMainHandItem();
+					if (itemInHand.getItem() instanceof ParagliderItem && ParagliderItem.isItemParagliding(itemInHand)) {
+						evt.setSwingHand(false);
+						evt.setCanceled(true);
+					}
+				});
+				MinecraftForge.EVENT_BUS.addListener((final DrawSelectionEvent.HighlightBlock evt) -> {
+					// disables drawing block highlights while paragliding (as blocks cannot be interacted with)
+					ItemStack itemInHand = Minecraft.getInstance().player.getMainHandItem();
+					if (itemInHand.getItem() instanceof ParagliderItem && ParagliderItem.isItemParagliding(itemInHand)) {
+						evt.setCanceled(true);
+					}
+				});
 			});
 		}
 

--- a/src/main/java/tictim/paraglider/event/ParagliderClientEventHandler.java
+++ b/src/main/java/tictim/paraglider/event/ParagliderClientEventHandler.java
@@ -8,7 +8,10 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.DrawSelectionEvent;
+import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.gui.ForgeIngameGui;
@@ -22,6 +25,7 @@ import tictim.paraglider.client.InGameStaminaWheelRenderer;
 import tictim.paraglider.client.StaminaWheelRenderer;
 import tictim.paraglider.client.screen.ParagliderSettingScreen;
 import tictim.paraglider.client.screen.StatueBargainScreen;
+import tictim.paraglider.item.ParagliderItem;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -105,6 +109,25 @@ public final class ParagliderClientEventHandler{
 		if(event.phase!=TickEvent.Phase.END) return;
 		if(Minecraft.getInstance().screen==null&&paragliderSettingsKey().consumeClick()){
 			Minecraft.getInstance().setScreen(new ParagliderSettingScreen());
+		}
+	}
+
+	@SubscribeEvent
+	public static void onClickInput(InputEvent.ClickInputEvent evt) {
+		// disables all interactions while paragliding
+		ItemStack itemInHand = Minecraft.getInstance().player.getMainHandItem();
+		if(itemInHand.getItem() instanceof ParagliderItem&&ParagliderItem.isItemParagliding(itemInHand)){
+			evt.setSwingHand(false);
+			evt.setCanceled(true);
+		}
+	}
+
+	@SubscribeEvent
+	public static void ondrawBlockSelection(DrawSelectionEvent.HighlightBlock evt) {
+		// disables drawing block highlights while paragliding (as blocks cannot be interacted with)
+		ItemStack itemInHand = Minecraft.getInstance().player.getMainHandItem();
+		if(itemInHand.getItem() instanceof ParagliderItem&&ParagliderItem.isItemParagliding(itemInHand)){
+			evt.setCanceled(true);
 		}
 	}
 }

--- a/src/main/java/tictim/paraglider/event/ParagliderClientEventHandler.java
+++ b/src/main/java/tictim/paraglider/event/ParagliderClientEventHandler.java
@@ -113,21 +113,22 @@ public final class ParagliderClientEventHandler{
 	}
 
 	@SubscribeEvent
-	public static void onClickInput(InputEvent.ClickInputEvent evt) {
+	public static void onClickInput(InputEvent.ClickInputEvent event) {
 		// disables all interactions while paragliding
-		ItemStack itemInHand = Minecraft.getInstance().player.getMainHandItem();
-		if(itemInHand.getItem() instanceof ParagliderItem&&ParagliderItem.isItemParagliding(itemInHand)){
-			evt.setSwingHand(false);
-			evt.setCanceled(true);
+		// this is necessary in addition to cancelling interactions in ParagliderEventHandler to also prevent the arm swing animation from playing
+		Player player = Minecraft.getInstance().player;
+		PlayerMovement m = PlayerMovement.of(player);
+		if(m!=null&&m.isParagliding()) {
+			event.setSwingHand(false);
+			event.setCanceled(true);
 		}
 	}
 
 	@SubscribeEvent
-	public static void ondrawBlockSelection(DrawSelectionEvent.HighlightBlock evt) {
-		// disables drawing block highlights while paragliding (as blocks cannot be interacted with)
-		ItemStack itemInHand = Minecraft.getInstance().player.getMainHandItem();
-		if(itemInHand.getItem() instanceof ParagliderItem&&ParagliderItem.isItemParagliding(itemInHand)){
-			evt.setCanceled(true);
-		}
+	public static void onDrawBlockSelection(DrawSelectionEvent.HighlightBlock event) {
+		// disables drawing block highlights while paragliding (as blocks cannot be interacted with, just a convenience feature to avoid confusing players)
+		Player player = Minecraft.getInstance().player;
+		PlayerMovement m = PlayerMovement.of(player);
+		if(m!=null&&m.isParagliding()) event.setCanceled(true);
 	}
 }

--- a/src/main/java/tictim/paraglider/event/ParagliderClientEventHandler.java
+++ b/src/main/java/tictim/paraglider/event/ParagliderClientEventHandler.java
@@ -8,7 +8,6 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.DrawSelectionEvent;
 import net.minecraftforge.client.event.InputEvent;
@@ -25,7 +24,6 @@ import tictim.paraglider.client.InGameStaminaWheelRenderer;
 import tictim.paraglider.client.StaminaWheelRenderer;
 import tictim.paraglider.client.screen.ParagliderSettingScreen;
 import tictim.paraglider.client.screen.StatueBargainScreen;
-import tictim.paraglider.item.ParagliderItem;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -113,19 +111,19 @@ public final class ParagliderClientEventHandler{
 	}
 
 	@SubscribeEvent
-	public static void onClickInput(InputEvent.ClickInputEvent event) {
+	public static void onClickInput(InputEvent.ClickInputEvent event){
 		// disables all interactions while paragliding
 		// this is necessary in addition to cancelling interactions in ParagliderEventHandler to also prevent the arm swing animation from playing
 		Player player = Minecraft.getInstance().player;
 		PlayerMovement m = PlayerMovement.of(player);
-		if(m!=null&&m.isParagliding()) {
+		if(m!=null&&m.isParagliding()){
 			event.setSwingHand(false);
 			event.setCanceled(true);
 		}
 	}
 
 	@SubscribeEvent
-	public static void onDrawBlockSelection(DrawSelectionEvent.HighlightBlock event) {
+	public static void onDrawBlockSelection(DrawSelectionEvent.HighlightBlock event){
 		// disables drawing block highlights while paragliding (as blocks cannot be interacted with, just a convenience feature to avoid confusing players)
 		Player player = Minecraft.getInstance().player;
 		PlayerMovement m = PlayerMovement.of(player);

--- a/src/main/java/tictim/paraglider/event/ParagliderEventHandler.java
+++ b/src/main/java/tictim/paraglider/event/ParagliderEventHandler.java
@@ -3,7 +3,6 @@ package tictim.paraglider.event;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
@@ -37,10 +36,21 @@ public final class ParagliderEventHandler{
 	@SubscribeEvent
 	public static void onPlayerInteract(PlayerInteractEvent event){
 		if(event.isCancelable()){
-			// use PlayerMovement instead of ServerPlayerMovement; this also needs to trigger client side to avoid desync
 			PlayerMovement m = PlayerMovement.of(event.getPlayer());
 			if(m!=null&&m.isParagliding()) event.setCanceled(true);
 		}
+	}
+
+	@SubscribeEvent
+	public static void onPlayerStartUseItem(LivingEntityUseItemEvent.Start event){
+		PlayerMovement m = PlayerMovement.of(event.getEntityLiving());
+		if(m!=null&&m.isParagliding()) event.setCanceled(true);
+	}
+
+	@SubscribeEvent
+	public static void onPlayerTickUseItem(LivingEntityUseItemEvent.Tick event){
+		PlayerMovement m = PlayerMovement.of(event.getEntityLiving());
+		if(m!=null&&m.isParagliding()) event.getEntityLiving().stopUsingItem();
 	}
 
 	@SubscribeEvent
@@ -51,24 +61,6 @@ public final class ParagliderEventHandler{
 		PlayerMovement m2 = PlayerMovement.of(event.getPlayer());
 		if(m1!=null&&m2!=null) m1.copyTo(m2);
 		original.invalidateCaps();
-	}
-
-	@SubscribeEvent
-	public static void onPlayerStartUseItem(LivingEntityUseItemEvent.Start event){
-		if(event.getEntityLiving() instanceof Player){
-			// use PlayerMovement instead of ServerPlayerMovement; this also needs to trigger client side to avoid desync
-			PlayerMovement m = PlayerMovement.of(event.getEntityLiving());
-			if(m!=null&&m.isParagliding()) event.setCanceled(true);
-		}
-	}
-
-	@SubscribeEvent
-	public static void onPlayerTickUseItem(LivingEntityUseItemEvent.Tick event){
-		if(event.getEntityLiving() instanceof Player){
-			// use PlayerMovement instead of ServerPlayerMovement; this also needs to trigger client side to avoid desync
-			PlayerMovement m = PlayerMovement.of(event.getEntityLiving());
-			if(m!=null&&m.isParagliding()) event.getEntityLiving().stopUsingItem();
-		}
 	}
 
 	private static final ResourceLocation MOVEMENT_HANDLER_KEY = new ResourceLocation(MODID, "paragliding_movement_handler");

--- a/src/main/java/tictim/paraglider/event/ParagliderEventHandler.java
+++ b/src/main/java/tictim/paraglider/event/ParagliderEventHandler.java
@@ -36,8 +36,9 @@ public final class ParagliderEventHandler{
 
 	@SubscribeEvent
 	public static void onPlayerInteract(PlayerInteractEvent event){
-		if(event.isCancelable()&&event.getHand()==InteractionHand.OFF_HAND){
-			ServerPlayerMovement m = ServerPlayerMovement.of(event.getPlayer());
+		if(event.isCancelable()){
+			// use PlayerMovement instead of ServerPlayerMovement; this also needs to trigger client side to avoid desync
+			PlayerMovement m = PlayerMovement.of(event.getPlayer());
 			if(m!=null&&m.isParagliding()) event.setCanceled(true);
 		}
 	}
@@ -53,9 +54,19 @@ public final class ParagliderEventHandler{
 	}
 
 	@SubscribeEvent
-	public static void onPlayerUseItem(LivingEntityUseItemEvent.Tick event){
-		if(event.getEntityLiving().getUsedItemHand()==InteractionHand.OFF_HAND&&event.getEntityLiving() instanceof Player){
-			ServerPlayerMovement m = ServerPlayerMovement.of(event.getEntityLiving());
+	public static void onPlayerStartUseItem(LivingEntityUseItemEvent.Start event){
+		if(event.getEntityLiving() instanceof Player){
+			// use PlayerMovement instead of ServerPlayerMovement; this also needs to trigger client side to avoid desync
+			PlayerMovement m = PlayerMovement.of(event.getEntityLiving());
+			if(m!=null&&m.isParagliding()) event.setCanceled(true);
+		}
+	}
+
+	@SubscribeEvent
+	public static void onPlayerTickUseItem(LivingEntityUseItemEvent.Tick event){
+		if(event.getEntityLiving() instanceof Player){
+			// use PlayerMovement instead of ServerPlayerMovement; this also needs to trigger client side to avoid desync
+			PlayerMovement m = PlayerMovement.of(event.getEntityLiving());
 			if(m!=null&&m.isParagliding()) event.getEntityLiving().stopUsingItem();
 		}
 	}


### PR DESCRIPTION
Hey there, really like the mod, nice job!

Just a little thing that bothered me: Even though both hands are holding the glider, you can still punch stuff and open containers while gliding. Also there is an inconsistence, where the arm swing shows in first person, but not in third person.

So I added a quick client side fix to disable all interactions while gliding. I also disabled drawing the highlight overlay, to make it a bit more clear that interactions are not possible while gliding.

Not sure where you want your client side event bus events, so I just put them in the main client class for now.